### PR TITLE
Link setup to purchase ticket, with better display

### DIFF
--- a/StyledComponents/partyScreen.js
+++ b/StyledComponents/partyScreen.js
@@ -19,5 +19,10 @@ export const styles = StyleSheet.create({
         width: 300,
         textAlign: "center",
         alignSelf: "center",
+    },
+    image: {
+        height: 200,
+        width: 350,
+        resizeMode: "cover",
     }
 })

--- a/components/PartyScreen.js
+++ b/components/PartyScreen.js
@@ -1,5 +1,5 @@
 import React from "react"
-import { View, Text, ScrollView } from "react-native"
+import { View, Text, ScrollView, Linking, Image } from "react-native"
 import { useSelector } from "react-redux"
 
 import { selectDetails } from "../store/party/selectors"
@@ -8,6 +8,22 @@ import { styles } from "../StyledComponents/partyScreen"
 export default function PartyScreen(){
     const details = useSelector(selectDetails)
     const custom = styles
+
+    function linkTicket(){
+        if(details.ticketLink !== null)
+        console.log("ticketlink", details.ticketLink)
+        Linking.openURL(`${details.ticketLink}`)
+    }
+
+    function ticketImage(){
+        if(details.ticketLink === null){
+                const noTicket = { uri: "https://gifimage.net/wp-content/uploads/2017/10/disappointed-gif.gif" }
+                return noTicket
+        } else {
+                const ticket = { uri: "https://vignette.wikia.nocookie.net/degrassi/images/1/19/Tumblr_lyu2b3q9cS1qjb59to1_500.gif/revision/latest/scale-to-width-down/340?cb=20141101014303"}
+                return ticket
+        }
+    }
     
     const displayDetails = () => {
         if(!details.id){
@@ -93,10 +109,11 @@ export default function PartyScreen(){
                     style={custom.textHead}>
                     Tickets:
                 </Text>
-                <Text
-                    style={custom.text}>
-                    {`${details.ticketLink === null ?"Tickets been pulled" :details.ticketLink}`}
-                </Text>
+                <Image
+                    source={ticketImage()}
+                    style={custom.image}
+                    onPress={() => linkTicket()}
+                />
                 </View>
             )
         }

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "@expo/vector-icons": "^10.2.1",
+    "@react-native-community/async-storage": "~1.11.0",
     "@react-native-community/masked-view": "0.1.10",
     "@react-navigation/bottom-tabs": "^5.8.0",
     "@react-navigation/material-top-tabs": "^5.2.16",
@@ -16,6 +17,8 @@
     "@react-navigation/stack": "^5.9.0",
     "axios": "^0.20.0",
     "expo": "~38.0.8",
+    "expo-linking": "^1.0.3",
+    "expo-secure-store": "~9.0.1",
     "expo-status-bar": "^1.0.2",
     "react": "~16.11.0",
     "react-dom": "~16.11.0",
@@ -31,9 +34,7 @@
     "react-redux": "^7.2.1",
     "redux": "^4.0.5",
     "redux-devtools-extension": "^2.13.8",
-    "redux-thunk": "^2.3.0",
-    "expo-secure-store": "~9.0.1",
-    "@react-native-community/async-storage": "~1.11.0"
+    "redux-thunk": "^2.3.0"
   },
   "devDependencies": {
     "@babel/core": "^7.8.6",


### PR DESCRIPTION
_**Minor update on Ticket Link:**_
I decided to implement the **Link** for the tickets, I did some research and came across **Linking** from **React Native** and was able to handle it with a **onPress.** I then decided that the **User** deserved a better acknowledgment of whether there were tickets or not. I achieved this through emotional **Gifs** to represent the **User's** emotions.  